### PR TITLE
Implement arithmetic operators with a macro

### DIFF
--- a/poly/src/polynomial/univariate/dense.rs
+++ b/poly/src/polynomial/univariate/dense.rs
@@ -285,14 +285,6 @@ impl<F: Field> DerefMut for DensePolynomial<F> {
     }
 }
 
-impl<F: Field> Add for DensePolynomial<F> {
-    type Output = DensePolynomial<F>;
-
-    fn add(self, other: DensePolynomial<F>) -> Self {
-        &self + &other
-    }
-}
-
 impl<'a, 'b, F: Field> Add<&'a DensePolynomial<F>> for &'b DensePolynomial<F> {
     type Output = DensePolynomial<F>;
 
@@ -487,15 +479,6 @@ impl<'a, 'b, F: Field> Sub<&'a DensePolynomial<F>> for &'b DensePolynomial<F> {
     }
 }
 
-impl<F: Field> Sub<DensePolynomial<F>> for DensePolynomial<F> {
-    type Output = DensePolynomial<F>;
-
-    #[inline]
-    fn sub(self, other: DensePolynomial<F>) -> DensePolynomial<F> {
-        &self - &other
-    }
-}
-
 impl<'a, 'b, F: Field> Sub<&'a SparsePolynomial<F>> for &'b DensePolynomial<F> {
     type Output = DensePolynomial<F>;
 
@@ -593,15 +576,6 @@ impl<'a, 'b, F: Field> Div<&'a DensePolynomial<F>> for &'b DensePolynomial<F> {
     }
 }
 
-impl<F: Field> Div<DensePolynomial<F>> for DensePolynomial<F> {
-    type Output = DensePolynomial<F>;
-
-    #[inline]
-    fn div(self, divisor: DensePolynomial<F>) -> DensePolynomial<F> {
-        &self / &divisor
-    }
-}
-
 impl<'b, F: Field> Mul<F> for &'b DensePolynomial<F> {
     type Output = DensePolynomial<F>;
 
@@ -647,13 +621,35 @@ impl<'a, 'b, F: FftField> Mul<&'a DensePolynomial<F>> for &'b DensePolynomial<F>
     }
 }
 
-impl<F: FftField> Mul<DensePolynomial<F>> for DensePolynomial<F> {
-    type Output = DensePolynomial<F>;
+macro_rules! impl_op {
+    ($trait:ident, $method:ident, $field_bound:ident) => {
+        impl<F: $field_bound> $trait<DensePolynomial<F>> for DensePolynomial<F> {
+            type Output = DensePolynomial<F>;
 
-    #[inline]
-    fn mul(self, other: DensePolynomial<F>) -> DensePolynomial<F> {
-        &self * &other
-    }
+            #[inline]
+            fn $method(self, other: DensePolynomial<F>) -> DensePolynomial<F> {
+                (&self).$method(&other)
+            }
+        }
+
+        impl<'a, F: $field_bound> $trait<&'a DensePolynomial<F>> for DensePolynomial<F> {
+            type Output = DensePolynomial<F>;
+
+            #[inline]
+            fn $method(self, other: &'a DensePolynomial<F>) -> DensePolynomial<F> {
+                (&self).$method(other)
+            }
+        }
+
+        impl<'a, F: $field_bound> $trait<DensePolynomial<F>> for &'a DensePolynomial<F> {
+            type Output = DensePolynomial<F>;
+
+            #[inline]
+            fn $method(self, other: DensePolynomial<F>) -> DensePolynomial<F> {
+                self.$method(&other)
+            }
+        }
+    };
 }
 
 impl<F: Field> Zero for DensePolynomial<F> {
@@ -667,6 +663,11 @@ impl<F: Field> Zero for DensePolynomial<F> {
         self.coeffs.is_empty() || self.coeffs.iter().all(|coeff| coeff.is_zero())
     }
 }
+
+impl_op!(Add, add, Field);
+impl_op!(Sub, sub, Field);
+impl_op!(Mul, mul, FftField);
+impl_op!(Div, div, Field);
 
 #[cfg(test)]
 mod tests {

--- a/poly/src/polynomial/univariate/dense.rs
+++ b/poly/src/polynomial/univariate/dense.rs
@@ -593,15 +593,6 @@ impl<'b, F: Field> Mul<F> for &'b DensePolynomial<F> {
     }
 }
 
-impl<F: Field> Mul<F> for DensePolynomial<F> {
-    type Output = DensePolynomial<F>;
-
-    #[inline]
-    fn mul(self, elem: F) -> DensePolynomial<F> {
-        &self * elem
-    }
-}
-
 /// Performs O(nlogn) multiplication of polynomials if F is smooth.
 impl<'a, 'b, F: FftField> Mul<&'a DensePolynomial<F>> for &'b DensePolynomial<F> {
     type Output = DensePolynomial<F>;


### PR DESCRIPTION
We realised the previous implementation of operators *, /, - for owned types (instead of references) broke some things. For instance, [this line in poly-commit](https://github.com/arkworks-rs/poly-commit/blob/12f5529c9ca609d07dd4683fcd1e196bc375eb0d/poly-commit/src/streaming_kzg/time.rs#L138) stopped compiling.

In the specific example given, the reason for the new failure is that, when operators were only implemented for &poly / &poly, the compiler implicitly converted the call `f_poly.div(&z_poly);` into `(&f_poly).div(&z_poly);`. But after we had added poly / poly, the compiler was not clever enough to add the reference and complained that poly / RHS should have RHS of type poly (not &poly).

Long story short, the best way to ensure the new operator definitions are not a breaking change is to implement poly / poly, poly / &poly and &poly / poly (all of them falling back to the honestly defined &poly / &poly). Since that had to be done for several operators, a macro seemed like the best approach.